### PR TITLE
Add pandas-compatible fallbacks for Spandas DataFrame and Series

### DIFF
--- a/spandas/__init__.py
+++ b/spandas/__init__.py
@@ -7,6 +7,6 @@ This module initializes the spandas package, setting up all core imports and exp
 the enhanced Spandas class with extended pandas-like functionality on top of Spark.
 """
 
-from .spandas import Spandas
+from .spandas import Spandas, SpandasSeries
 
-__all__ = ["Spandas"]
+__all__ = ["Spandas", "SpandasSeries"]


### PR DESCRIPTION
## Summary
- expose pandas-like wrappers for Spark DataFrame and Series
- provide automatic fallback to pandas implementations for missing methods
- export new `SpandasSeries` alongside `Spandas`

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899dfa330c88326aa9641355f9d9f0c