### PR TITLE
Handle integer column indices in iloc

### DIFF
--- a/spandas/enhanced/selection/indexing.py
+++ b/spandas/enhanced/selection/indexing.py
@@ -61,7 +61,13 @@ def iloc(
         return pdf.iloc[row_idx, col_idx] if col_idx is not None else pdf.iloc[row_idx]
 
     cols = list(self.columns)
-    selected_cols = cols[col_idx] if col_idx is not None else cols
+    if col_idx is not None:
+        if isinstance(col_idx, int):
+            selected_cols = [cols[col_idx]]
+        else:
+            selected_cols = cols[col_idx]
+    else:
+        selected_cols = cols
     indexed = self.withColumn("__row_id", F.monotonically_increasing_id())
     if isinstance(row_idx, int):
         filtered = indexed.filter(F.col("__row_id") == row_idx)


### PR DESCRIPTION
## Summary
- ensure `iloc` always passes a list of columns to Spark `select`

## Testing
- `pytest`
- manual `iloc` calls selecting columns by integer index

------
https://chatgpt.com/codex/tasks/task_e_6899e3ec05888326b4f084656254be7e