### PR TITLE
Add join and iloc tests and document test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ sdf.plot()
 - `enhanced/` - Feature-specific enhancements (apply, selection, mathstats, etc.)
 - `spandas.py` - Main class that binds all enhanced functionality
 
+### テストの実行 / Running Tests
+
+プロジェクトのルートディレクトリで以下を実行することで、ユニットテストを実行できます。
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
 ---
 
 ## 📄 License / ライセンス

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyspark>=3.4.0
 pandas>=1.5.0
 swifter>=1.3.0
 matplotlib>=3.5.0
+pytest>=7.4.0

--- a/tests/test_join_ext.py
+++ b/tests/test_join_ext.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import pandas.testing as tm
+import pyspark.pandas as ps
+from pyspark.sql import SparkSession
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from spandas.enhanced import join_ext
+
+SparkSession.builder.config("spark.sql.ansi.enabled", "false").getOrCreate()
+
+
+def test_merge_returns_expected_frame():
+    left = ps.DataFrame({'key': [1, 2], 'value1': [10, 20]})
+    right = ps.DataFrame({'key': [1, 2], 'value2': [100, 200]})
+    result = join_ext.merge(left, right, on='key')
+    expected = ps.DataFrame({'key': [1, 2], 'value1': [10, 20], 'value2': [100, 200]})
+    tm.assert_frame_equal(
+        result.sort_values('key').to_pandas().reset_index(drop=True),
+        expected.sort_values('key').to_pandas().reset_index(drop=True),
+    )
+
+
+def test_join_returns_expected_frame():
+    left = ps.DataFrame({'value1': [10, 20]}, index=[1, 2])
+    right = ps.DataFrame({'value2': [100, 200]}, index=[1, 2])
+    result = join_ext.join(left, right, how='inner')
+    expected = ps.DataFrame({'value1': [10, 20], 'value2': [100, 200]}, index=[1, 2])
+    tm.assert_frame_equal(
+        result.sort_index().to_pandas(),
+        expected.sort_index().to_pandas(),
+    )

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import pandas.testing as tm
+import pyspark.pandas as ps
+from pyspark.sql import SparkSession
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from spandas.enhanced.selection import iloc
+
+SparkSession.builder.config("spark.sql.ansi.enabled", "false").getOrCreate()
+
+
+def test_iloc_with_integer_col_idx_selects_correct_column():
+    df = ps.DataFrame({'A': [1, 2], 'B': [3, 4], 'C': [5, 6]})
+    result = iloc(df, slice(0, 2), 1, to_pandas=True)
+    expected = df.to_pandas().iloc[0:2, 1]
+    tm.assert_series_equal(result.reset_index(drop=True), expected.reset_index(drop=True))


### PR DESCRIPTION
## Summary
- add join_ext merge/join tests to validate simple DataFrame combinations
- add selection.iloc test for integer column index
- document running tests and include pytest in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899e3f4ef18832695e83be9f57662db