### PR TITLE
Pin dependency versions for PySpark 3 and pandas 1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Spark上でのDataFrame操作を強化するライブラリです。
 pip install git+https://github.com/zeusu-sato/spandas.git
 ```
 
+> **注意:** 本ライブラリは PySpark 3 系および pandas 1 系を前提としており、
+> PySpark 4.x や pandas 2.x には未対応です。
+
 ### 使用例
 
 ```python
@@ -57,6 +60,9 @@ including easy-to-use methods, parallelism with swifter, and plotting support vi
 ```bash
 pip install git+https://github.com/zeusu-sato/spandas.git
 ```
+
+> **Note:** The package currently targets PySpark 3.x and pandas 1.x.
+> PySpark 4.x and pandas 2.x are not yet supported.
 
 ### Example
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-pyspark>=3.4.0
-pandas>=1.5.0
+pyspark>=3.2.0,<4.0
+pandas>=1.5.0,<2.0
+numpy>=1.20,<2.0
 swifter>=1.3.0
+dask>=2.10.0,<2024.0
 matplotlib>=3.5.0
 pytest>=7.4.0

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,11 @@ setup(
     url='https://github.com/zeusu-sato/spandas',
     packages=find_packages(include=["spandas", "spandas.*"]),
     install_requires=[
-        'pyspark>=3.2.0',
+        'pyspark>=3.2.0,<4.0',
+        'pandas>=1.0,<2.0',
+        'numpy>=1.20,<2.0',
         'swifter',
-        'matplotlib'
+        'matplotlib',
     ],
     python_requires='>=3.7',
 )


### PR DESCRIPTION
## Summary
- Limit PySpark to <4 and pandas/numpy to 1.x to prevent environment conflicts
- Constrain dev requirements (including dask) to versions compatible with pandas 1.x
- Document PySpark 3.x & pandas 1.x requirement in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899e93e4f5c83268e480c35ee4890b0