### PR TITLE
Support PySpark 4.x and pandas 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## 🇯🇵 Spandas - Spark上でpandasのように使える拡張DataFrame
 
-**Spandas** は、pandas-on-Spark（pyspark.pandas）をベースに、pandasのような使いやすさと、swifterによる並列処理、matplotlib対応の可視化などを統合し、
+**Spandas** は、PySpark の pandas API (`from pyspark import pandas as ps`) をベースに、pandasのような使いやすさと、swifterによる並列処理、matplotlib対応の可視化などを統合し、
 Spark上でのDataFrame操作を強化するライブラリです。
 
 ### 特徴
@@ -17,14 +17,13 @@ Spark上でのDataFrame操作を強化するライブラリです。
 pip install git+https://github.com/zeusu-sato/spandas.git
 ```
 
-> **注意:** 本ライブラリは PySpark 3 系および pandas 1 系を前提としており、
-> PySpark 4.x や pandas 2.x には未対応です。
+> **注意:** 本ライブラリは PySpark 4 系および pandas 2 系以降に対応しています。
 
 ### 使用例
 
 ```python
 from spandas import Spandas
-import pyspark.pandas as ps
+from pyspark import pandas as ps
 
 psdf = ps.read_csv("sample.csv")
 sdf = Spandas(psdf)
@@ -44,7 +43,7 @@ sdf.plot()
 
 ## 🇺🇸 Spandas - Enhanced DataFrame API on Spark with Pandas-like Syntax
 
-**Spandas** extends pandas-on-Spark (pyspark.pandas) to provide a more pandas-like experience,
+**Spandas** extends PySpark's pandas API (`from pyspark import pandas as ps`) to provide a more pandas-like experience,
 including easy-to-use methods, parallelism with swifter, and plotting support via matplotlib.
 
 ### Features
@@ -61,14 +60,13 @@ including easy-to-use methods, parallelism with swifter, and plotting support vi
 pip install git+https://github.com/zeusu-sato/spandas.git
 ```
 
-> **Note:** The package currently targets PySpark 3.x and pandas 1.x.
-> PySpark 4.x and pandas 2.x are not yet supported.
+> **Note:** The package targets PySpark 4.x and pandas 2.x or newer.
 
 ### Example
 
 ```python
 from spandas import Spandas
-import pyspark.pandas as ps
+from pyspark import pandas as ps
 
 psdf = ps.read_csv("sample.csv")
 sdf = Spandas(psdf)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-pyspark>=3.2.0,<4.0
-pandas>=1.5.0,<2.0
-numpy>=1.20,<2.0
+pyspark>=4.0.0
+pandas>=2.0
+numpy>=1.22
 swifter>=1.3.0
 dask>=2.10.0,<2024.0
 matplotlib>=3.5.0
 pytest>=7.4.0
+pyarrow>=11.0.0

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,12 @@ setup(
     url='https://github.com/zeusu-sato/spandas',
     packages=find_packages(include=["spandas", "spandas.*"]),
     install_requires=[
-        'pyspark>=3.2.0,<4.0',
-        'pandas>=1.0,<2.0',
-        'numpy>=1.20,<2.0',
+        'pyspark>=4.0.0',
+        'pandas>=2.0',
+        'numpy>=1.22',
         'swifter',
         'matplotlib',
+        'pyarrow>=11.0.0',
     ],
     python_requires='>=3.7',
 )

--- a/spandas/compat.py
+++ b/spandas/compat.py
@@ -1,0 +1,9 @@
+"""Compatibility helpers for PySpark pandas API across versions."""
+
+try:
+    import pyspark.pandas as ps  # PySpark < 4.x
+except ImportError:  # pragma: no cover - for PySpark >= 4.x
+    from pyspark import pandas as ps  # type: ignore
+
+__all__ = ["ps"]
+

--- a/spandas/enhanced/aggregation/aggregation.py
+++ b/spandas/enhanced/aggregation/aggregation.py
@@ -8,7 +8,7 @@ __all__ = ["agg", "groupby", "describe"]
 
 from typing import Union, Callable, List, Dict, Optional
 import pandas as pd
-import pyspark.pandas as ps
+from spandas.compat import ps
 
 
 def agg(

--- a/spandas/enhanced/apply_ext.py
+++ b/spandas/enhanced/apply_ext.py
@@ -5,7 +5,7 @@ spandas.enhanced.apply: Enhanced versions of apply, applymap, and map using swif
 """
 
 import pandas as pd
-import pyspark.pandas as ps
+from spandas.compat import ps
 from typing import Callable, Any, Union, Optional
 
 __all__ = [

--- a/spandas/enhanced/join_ext.py
+++ b/spandas/enhanced/join_ext.py
@@ -11,7 +11,7 @@ __all__ = ["merge", "join", "concat", "combine_first"]
 
 from typing import Union, List, Optional
 import pandas as pd
-import pyspark.pandas as ps
+from spandas.compat import ps
 
 
 def merge(

--- a/spandas/enhanced/mathstats/correlation.py
+++ b/spandas/enhanced/mathstats/correlation.py
@@ -10,7 +10,7 @@ Provides:
 """
 
 from typing import Optional
-import pyspark.pandas as ps
+from spandas.compat import ps
 import pandas as pd
 
 def corr(

--- a/spandas/enhanced/mathstats/interpolation.py
+++ b/spandas/enhanced/mathstats/interpolation.py
@@ -8,7 +8,7 @@ Provides:
 """
 
 from typing import Literal, Optional
-import pyspark.pandas as ps
+from spandas.compat import ps
 import pandas as pd
 
 

--- a/spandas/enhanced/mathstats/timeseries.py
+++ b/spandas/enhanced/mathstats/timeseries.py
@@ -5,7 +5,7 @@ spandas.enhanced.mathstats.timeseries: Implements time series operations like re
 """
 
 from typing import Union, Optional, Callable
-import pyspark.pandas as ps
+from spandas.compat import ps
 import pandas as pd
 
 

--- a/spandas/enhanced/missing.py
+++ b/spandas/enhanced/missing.py
@@ -6,7 +6,7 @@ spandas.enhanced.missing: Enhanced missing data handling methods.
 
 from typing import Any, Union
 import pandas as pd
-import pyspark.pandas as ps
+from spandas.compat import ps
 
 __all__ = [
     "isna",

--- a/spandas/enhanced/plot_ext/boxplot_ext.py
+++ b/spandas/enhanced/plot_ext/boxplot_ext.py
@@ -10,7 +10,7 @@ them to pandas and using matplotlib. Spark does not natively support box plots.
 __all__ = ["boxplot"]
 
 from typing import Any
-import pyspark.pandas as ps
+from spandas.compat import ps
 
 
 def boxplot(self: ps.DataFrame, *args, **kwargs) -> Any:

--- a/spandas/enhanced/plot_ext/hist_ext.py
+++ b/spandas/enhanced/plot_ext/hist_ext.py
@@ -10,7 +10,7 @@ them to pandas and using matplotlib. Spark does not natively support plotting hi
 __all__ = ["hist"]
 
 from typing import Any
-import pyspark.pandas as ps
+from spandas.compat import ps
 
 
 def hist(self: ps.DataFrame, *args, **kwargs) -> Any:

--- a/spandas/enhanced/plot_ext/plot_ext.py
+++ b/spandas/enhanced/plot_ext/plot_ext.py
@@ -10,7 +10,7 @@ by converting them to pandas and using matplotlib. Spark native plotting is unsu
 __all__ = ["plot"]
 
 from typing import Any
-import pyspark.pandas as ps
+from spandas.compat import ps
 
 
 def plot(self: ps.DataFrame, *args, **kwargs) -> Any:

--- a/spandas/enhanced/reshape/melting.py
+++ b/spandas/enhanced/reshape/melting.py
@@ -11,7 +11,7 @@ __all__ = ["melt", "wide_to_long"]
 
 from typing import Optional, List
 import pandas as pd
-import pyspark.pandas as ps
+from spandas.compat import ps
 
 
 def melt(

--- a/spandas/enhanced/reshape/pivoting.py
+++ b/spandas/enhanced/reshape/pivoting.py
@@ -7,7 +7,7 @@ or best-effort fallbacks.
 """
 
 from typing import Any, Optional, Union, List
-import pyspark.pandas as ps
+from spandas.compat import ps
 import pandas as pd
 
 __all__ = ["pivot", "pivot_table", "stack", "unstack"]

--- a/spandas/enhanced/reshape/reshaping.py
+++ b/spandas/enhanced/reshape/reshaping.py
@@ -11,7 +11,7 @@ __all__ = ["explode", "get_dummies", "transpose", "T"]
 
 from typing import Union, List, Optional
 import pandas as pd
-import pyspark.pandas as ps
+from spandas.compat import ps
 
 
 def explode(

--- a/spandas/enhanced/selection/filter_mask.py
+++ b/spandas/enhanced/selection/filter_mask.py
@@ -5,7 +5,7 @@ spandas.enhanced.selection.filter_mask: Boolean filtering utilities (isin, where
 """
 
 from typing import Any, Union, List, Callable
-import pyspark.pandas as ps
+from spandas.compat import ps
 import pandas as pd
 
 __all__ = ["isin", "where", "mask"]

--- a/spandas/enhanced/selection/indexing.py
+++ b/spandas/enhanced/selection/indexing.py
@@ -7,7 +7,7 @@ Supports both best-effort Spark-based logic and fallback to to_pandas for full c
 
 from typing import Union, Any, Tuple, Optional
 import pandas as pd
-import pyspark.pandas as ps
+from spandas.compat import ps
 import pyspark.sql.functions as F
 
 __all__ = ["loc", "iloc", "at", "iat", "xs"]

--- a/spandas/enhanced/selection/slicing.py
+++ b/spandas/enhanced/selection/slicing.py
@@ -6,7 +6,7 @@ with optional pandas fallback for full fidelity.
 """
 
 from typing import Union, Optional
-import pyspark.pandas as ps
+from spandas.compat import ps
 import pandas as pd
 import pyspark.sql.functions as F
 

--- a/spandas/original/backup.py
+++ b/spandas/original/backup.py
@@ -7,7 +7,7 @@ These methods preserve the unmodified behavior of the parent class
 for fallback or comparison purposes.
 """
 
-import pyspark.pandas as ps
+from spandas.compat import ps
 import pandas as pd
 from typing import Any, Callable, List, Union
 

--- a/spandas/spandas.py
+++ b/spandas/spandas.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from typing import Any, Callable
 
 import pandas as pd
-import pyspark.pandas as ps
+from spandas.compat import ps
 
 from spandas.original import backup as original
 from spandas.enhanced import (

--- a/tests/test_join_ext.py
+++ b/tests/test_join_ext.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import pandas.testing as tm
-import pyspark.pandas as ps
+from pyspark import pandas as ps
 from pyspark.sql import SparkSession
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import pandas.testing as tm
-import pyspark.pandas as ps
+from pyspark import pandas as ps
 from pyspark.sql import SparkSession
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))


### PR DESCRIPTION
## Summary
- add compatibility layer for PySpark's pandas API so the library works with PySpark 4.x
- bump dependencies to PySpark 4 and pandas 2 and include pyarrow
- document new version support and import path in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899f81800ec8326aa29df53c00dc166