### PR TITLE
Add smoke test and skip Spark tests by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,5 @@ jobs:
           assert iu.find_spec("spandas")
           print("OK", spandas.__version__, pd.__version__)
           PY
+      - name: Run tests
+        run: pytest -q

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    spark: tests requiring pyspark / spark runtime
+

--- a/tests/test_join_ext.py
+++ b/tests/test_join_ext.py
@@ -1,13 +1,21 @@
 import os
 import sys
-import pandas.testing as tm
-from pyspark import pandas as ps
-from pyspark.sql import SparkSession
+import pytest
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from spandas.enhanced import join_ext
+run_spark = os.getenv("SPANDAS_RUN_SPARK_TESTS") == "1"
+pytestmark = [
+    pytest.mark.spark,
+    pytest.mark.skipif(not run_spark, reason="spark tests disabled in CI by default"),
+]
 
-SparkSession.builder.config("spark.sql.ansi.enabled", "false").getOrCreate()
+if run_spark:
+    import pandas.testing as tm
+    from pyspark import pandas as ps
+    from pyspark.sql import SparkSession
+
+    SparkSession.builder.config("spark.sql.ansi.enabled", "false").getOrCreate()
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    from spandas.enhanced import join_ext
 
 
 def test_merge_returns_expected_frame():

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,13 +1,21 @@
 import os
 import sys
-import pandas.testing as tm
-from pyspark import pandas as ps
-from pyspark.sql import SparkSession
+import pytest
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from spandas.enhanced.selection import iloc
+run_spark = os.getenv("SPANDAS_RUN_SPARK_TESTS") == "1"
+pytestmark = [
+    pytest.mark.spark,
+    pytest.mark.skipif(not run_spark, reason="spark tests disabled in CI by default"),
+]
 
-SparkSession.builder.config("spark.sql.ansi.enabled", "false").getOrCreate()
+if run_spark:
+    import pandas.testing as tm
+    from pyspark import pandas as ps
+    from pyspark.sql import SparkSession
+
+    SparkSession.builder.config("spark.sql.ansi.enabled", "false").getOrCreate()
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    from spandas.enhanced.selection import iloc
 
 
 def test_iloc_with_integer_col_idx_selects_correct_column():

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+
+def test_import_and_version():
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    import spandas
+
+    assert hasattr(spandas, "__version__")
+


### PR DESCRIPTION
## Summary
- ensure at least one test is collected by adding a smoke test that imports `spandas`
- skip Spark-dependent tests unless `SPANDAS_RUN_SPARK_TESTS=1` and register a `spark` marker
- run tests in CI workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689af38e147083268e5bc27d7194e06d