### PR TITLE
Pin dask dependencies and refine CI install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,10 @@ jobs:
         with:
           python-version: "3.10"
       - run: python -m pip install -U pip
-      - run: pip install -c constraints.txt .[local]
+      - name: Install base (constrained)
+        run: pip install -U -c constraints.txt .
+      - name: Install extras (unconstrained)
+        run: pip install -U ".[local]" ".[dask_legacy]"
       - run: pip check
-      - run: |
-          python - <<'PY'
-          import spandas, pandas as pd, importlib.util as iu
-          assert iu.find_spec("spandas")
-          print("OK", spandas.__version__, pd.__version__)
-          PY
+      - name: Run tests
+        run: pytest -q

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,6 +1,7 @@
 pandas<2.0
-dask==2024.4.2  # pin compatible with dask-expr 1.0.14
-dask-expr==1.0.14
-pyarrow<13
+numpy<2.0
 matplotlib<3.8
-swifter==1.4.0
+pyarrow<13
+swifter<1.5
+dask-expr<1.0
+dask>=2024.2,<2024.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,17 @@ dependencies = [
   "pyarrow>=8,<13",
   "matplotlib>=3.7,<3.8",
   "swifter>=1.4,<1.5",
-  "dask[dataframe]>=2024.2,<2024.7",
-  "dask-expr>=1.0,<1.1",
 ]
 
 [project.optional-dependencies]
-local = ["pyspark>=3.5,<3.6"]  # ローカル検証用。Databricksでは使わない
+dask_legacy = [
+  "dask[dataframe]>=2024.2,<2024.7",
+  "dask-expr<1.0",
+  "swifter>=1.4,<1.5",
+]
+local = [
+  "pytest>=7.4",
+]
 
 [tool.setuptools]
-packages = ["spandas"]
+packages = ["spandas", "spandas.enhanced", "spandas.original"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,4 @@ numpy>=1.22,<2.0
 pyarrow>=8,<13
 matplotlib>=3.7,<3.8
 swifter>=1.4,<1.5
-dask[dataframe]>=2024.2,<2024.7
-dask-expr>=1.0,<1.1
 pytest>=7.4.0

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,16 @@ setup(
         'pyarrow>=8,<13',
         'matplotlib>=3.7,<3.8',
         'swifter>=1.4,<1.5',
-        'dask[dataframe]>=2024.2,<2024.7',
-        'dask-expr>=1.0,<1.1',
     ],
     extras_require={
-        'local': ['pyspark>=3.5,<3.6'],
+        'dask_legacy': [
+            'dask[dataframe]>=2024.2,<2024.7',
+            'dask-expr<1.0',
+            'swifter>=1.4,<1.5',
+        ],
+        'local': [
+            'pytest>=7.4',
+        ],
     },
     python_requires='>=3.10,<3.12',
 )


### PR DESCRIPTION
## Summary
- limit core dependencies to pandas/numpy/pyarrow/matplotlib/swifter
- add `dask_legacy` and `local` extras with pinned `dask-expr<1.0`
- split CI to install base with constraints and extras separately

## Testing
- `pip check`
- `pip install .[dask_legacy]` *(fails: ResolutionImpossible – `dask-expr` requires pandas>=2)*
- `pytest -q` *(fails: ImportError: cannot import name 'selection' from partially initialized module 'spandas.enhanced')*

------
https://chatgpt.com/codex/tasks/task_e_689af707515483269a635bc9e4469f97