### PR TITLE
feat(databricks): slim core deps; move pyspark/dask to extras; stabilize CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,42 @@
 name: CI
 on: [push, pull_request]
+
 jobs:
-  test:
+  base:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install -U pip
+      - run: pip install -U .
+      - run: pytest -q
+
+  optional-extras:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - extra: dask_legacy
+            install: ".[dask_legacy]"
+            pytest-args: "-m 'dask'"
+            env: {}
+          - extra: spark
+            install: ".[spark]"
+            pytest-args: "-m 'spark'"
+            env:
+              SPANDAS_ENABLE_SPARK_TESTS: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - run: python -m pip install -U pip
-      - run: pip install -c constraints.txt .[local]
-      - run: pip check
-      - run: |
-          python - <<'PY'
-          import spandas, pandas as pd, importlib.util as iu
-          assert iu.find_spec("spandas")
-          print("OK", spandas.__version__, pd.__version__)
-          PY
+      - run: pip install -U .
+      - run: pip install -U "${{ matrix.install }}"
+      - run: pytest -q ${{ matrix.pytest-args }}
+        env: ${{ matrix.env }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.0
+
+- Minimize core dependencies for Databricks runtime (pandas/numpy/pyarrow/matplotlib only)
+- Move `pyspark` and `dask` to optional extras `[spark]` and `[dask_legacy]`
+- Simplify CI without constraints; add optional jobs for extras
+
 ## 0.1.1
 
 - Drop `pyspark` from default dependencies; provide `spandas[local]` extra for local verification.

--- a/README.md
+++ b/README.md
@@ -1,34 +1,28 @@
-## 🇯🇵 Spandas - Spark上でpandasのように使える拡張DataFrame
+## 🇯🇵 Spandas - Databricks 向けの軽量拡張
 
-**Spandas** は、PySpark の pandas API (`from pyspark import pandas as ps`) をベースに、pandasのような使いやすさと、swifterによる並列処理、matplotlib対応の可視化などを統合し、
-Spark上でのDataFrame操作を強化するライブラリです。
+**Spandas** は、PySpark の pandas API (`from pyspark import pandas as ps`) をベースに、pandas のような使いやすさで Spark 上の DataFrame 操作を強化する、Databricks ランタイム向けの軽量ライブラリです。
 
 ### 特徴
 
 - pandasのような `.apply()`, `.agg()`, `.groupby()` などの操作をSpark上で再現
-- `swifter` による自動並列化
 - `.plot()`, `.hist()`, `.boxplot()` による可視化（pandas経由）
 - `to_pandas=False` によるSparkネイティブなベストエフォート処理
 - `.loc`, `.iloc`, `.T`, `.pivot`, `.melt` など、使い慣れたAPIをサポート
 
 ### インストール
 
-Databricks での推奨手順:
+Databricks では次のコマンドだけで利用できます:
 
-```python
-%pip install -U -c https://raw.githubusercontent.com/zeusu-sato/spandas/main/constraints.txt \
-  "spandas @ git+https://github.com/zeusu-sato/spandas.git"
-dbutils.library.restartPython()
+```bash
+pip install spandas
 ```
 
-トラブル時の最小インストール:
+オプション機能:
 
-```python
-%pip install -U --no-deps "spandas @ git+https://github.com/zeusu-sato/spandas.git"
-dbutils.library.restartPython()
-```
+- **Dask 連携:** `pip install "spandas[dask_legacy]"`
+- **ローカル Spark 検証:** `pip install "spandas[spark]"`
 
-> **注意:** 本ライブラリは PySpark 3.5 系および pandas 1.5 系に対応しています。
+> **注意:** 本ライブラリは PySpark 3.5 系および pandas 1.x 系に対応しています。
 
 ### 使用例
 
@@ -52,37 +46,31 @@ sdf.plot()
 
 ---
 
-## 🇺🇸 Spandas - Enhanced DataFrame API on Spark with Pandas-like Syntax
+## 🇺🇸 Spandas - Lightweight Extensions for Databricks
 
-**Spandas** extends PySpark's pandas API (`from pyspark import pandas as ps`) to provide a more pandas-like experience,
-including easy-to-use methods, parallelism with swifter, and plotting support via matplotlib.
+**Spandas** extends PySpark's pandas API (`from pyspark import pandas as ps`) to provide a pandas-like experience on Spark.
 
 ### Features
 
 - Familiar pandas-style API on Spark: `.apply()`, `.agg()`, `.groupby()`, etc.
-- Automatic parallelization using `swifter`
 - Plotting via `.plot()`, `.hist()`, `.boxplot()` (backed by pandas/matplotlib)
 - Best-effort native Spark execution with `to_pandas=False`
 - Support for `.loc`, `.iloc`, `.T`, `.pivot`, `.melt`, and more
 
 ### Installation
 
-Recommended installation on Databricks:
+On Databricks just run:
 
-```python
-%pip install -U -c https://raw.githubusercontent.com/zeusu-sato/spandas/main/constraints.txt \
-  "spandas @ git+https://github.com/zeusu-sato/spandas.git"
-dbutils.library.restartPython()
+```bash
+pip install spandas
 ```
 
-Minimal install (rely on DBR-bundled deps):
+Optional extras:
 
-```python
-%pip install -U --no-deps "spandas @ git+https://github.com/zeusu-sato/spandas.git"
-dbutils.library.restartPython()
-```
+- **Dask integration:** `pip install "spandas[dask_legacy]"`
+- **Local Spark testing:** `pip install "spandas[spark]"`
 
-> **Note:** The package targets PySpark 3.5.x and pandas 1.5.x (Databricks Runtime compatible).
+> **Note:** The package targets PySpark 3.5.x and pandas 1.x (Databricks Runtime compatible).
 
 ### Example
 
@@ -103,15 +91,6 @@ sdf.plot()
 - `original/` - Backups of original pandas-on-Spark methods
 - `enhanced/` - Feature-specific enhancements (apply, selection, mathstats, etc.)
 - `spandas.py` - Main class that binds all enhanced functionality
-
-### テストの実行 / Running Tests
-
-プロジェクトのルートディレクトリで以下を実行することで、ユニットテストを実行できます。
-
-```bash
-pip install -r requirements.txt
-pytest
-```
 
 ---
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,6 +1,0 @@
-pandas<2.0
-dask==2024.4.2  # pin compatible with dask-expr 1.0.14
-dask-expr==1.0.14
-pyarrow<13
-matplotlib<3.8
-swifter==1.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spandas"
-version = "0.1.1"
+version = "0.2.0"
 description = "Spark + pandas hybrid utilities"
 readme = "README.md"
 requires-python = ">=3.10,<3.12"
@@ -17,13 +17,11 @@ dependencies = [
   "numpy>=1.22,<2.0",
   "pyarrow>=8,<13",
   "matplotlib>=3.7,<3.8",
-  "swifter>=1.4,<1.5",
-  "dask[dataframe]>=2024.2,<2024.7",
-  "dask-expr>=1.0,<1.1",
 ]
 
 [project.optional-dependencies]
-local = ["pyspark>=3.5,<3.6"]  # ローカル検証用。Databricksでは使わない
+spark = ["pyspark>=3.5,<3.6"]
+dask_legacy = ["dask[dataframe]==2023.9.3"]
 
 [tool.setuptools]
 packages = ["spandas"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    spark: tests requiring PySpark
+    dask: tests requiring Dask

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,4 @@ pandas>=1.5,<2.0
 numpy>=1.22,<2.0
 pyarrow>=8,<13
 matplotlib>=3.7,<3.8
-swifter>=1.4,<1.5
-dask[dataframe]>=2024.2,<2024.7
-dask-expr>=1.0,<1.1
 pytest>=7.4.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='spandas',
-    version='0.1.1',
+    version='0.2.0',
     description='Spark + pandas hybrid utilities',
     author='Zeusu Sato',
     author_email='zeusu.sato@dorodango.biz',
@@ -13,12 +13,10 @@ setup(
         'numpy>=1.22,<2.0',
         'pyarrow>=8,<13',
         'matplotlib>=3.7,<3.8',
-        'swifter>=1.4,<1.5',
-        'dask[dataframe]>=2024.2,<2024.7',
-        'dask-expr>=1.0,<1.1',
     ],
     extras_require={
-        'local': ['pyspark>=3.5,<3.6'],
+        'spark': ['pyspark>=3.5,<3.6'],
+        'dask_legacy': ['dask[dataframe]==2023.9.3'],
     },
     python_requires='>=3.10,<3.12',
 )

--- a/spandas/__init__.py
+++ b/spandas/__init__.py
@@ -6,13 +6,23 @@ Spandas Package Initialization
 This module initializes the spandas package, setting up all core imports and exposing
 the enhanced Spandas class with extended pandas-like functionality on top of Spark.
 """
+import pandas as _pd
+
+# Guard against pandas 2.x until the project officially supports it.
+# TODO: Remove this once pandas>=2 compatibility is added.
+major = int(_pd.__version__.split('.')[0])
+if major >= 2:
+    raise RuntimeError(
+        "spandas is built for Databricks runtime (pandas<2). "
+        "Please install spandas[dask_legacy] or pin pandas<2."
+    )
 
 try:
     import pyspark  # noqa: F401
 except Exception as e:  # pragma: no cover - simple import guard
     raise RuntimeError(
         "pyspark が見つかりません。Databricks では同梱されています。"
-        "ローカルで使う場合は `pip install pyspark` か `pip install spandas[local]` を実行してください。"
+        "ローカルで使う場合は `pip install spandas[spark]` を実行してください。"
     ) from e
 
 from importlib.metadata import PackageNotFoundError, version

--- a/spandas/spandas.py
+++ b/spandas/spandas.py
@@ -38,7 +38,7 @@ from spandas.enhanced import (
 class Spandas(ps.DataFrame):
     """
     Spandas: An enhanced DataFrame class combining pandas-like ease of use
-    with Spark's scalability, powered by pandas-on-Spark and swifter.
+    with Spark's scalability, powered by pandas-on-Spark.
     """
 
     # --------- Original Methods ---------

--- a/tests/test_dask_basic.py
+++ b/tests/test_dask_basic.py
@@ -1,0 +1,14 @@
+import pytest
+import pandas as pd
+
+pytestmark = pytest.mark.dask
+
+try:
+    import dask.dataframe as dd
+except Exception:
+    pytest.skip("dask not available", allow_module_level=True)
+
+
+def test_dask_dataframe_sum():
+    df = dd.from_pandas(pd.DataFrame({"a": [1, 2, 3]}), npartitions=1)
+    assert df.a.sum().compute() == 6

--- a/tests/test_join_ext.py
+++ b/tests/test_join_ext.py
@@ -1,8 +1,19 @@
 import os
 import sys
 import pandas.testing as tm
-from pyspark import pandas as ps
-from pyspark.sql import SparkSession
+import pytest
+
+spark_enabled = os.getenv("SPANDAS_ENABLE_SPARK_TESTS") == "1"
+pytestmark = [
+    pytest.mark.spark,
+    pytest.mark.skipif(not spark_enabled, reason="spark tests disabled by default"),
+]
+
+try:
+    from pyspark import pandas as ps
+    from pyspark.sql import SparkSession
+except Exception:
+    pytest.skip("pyspark not available", allow_module_level=True)
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from spandas.enhanced import join_ext

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,8 +1,19 @@
 import os
 import sys
 import pandas.testing as tm
-from pyspark import pandas as ps
-from pyspark.sql import SparkSession
+import pytest
+
+spark_enabled = os.getenv("SPANDAS_ENABLE_SPARK_TESTS") == "1"
+pytestmark = [
+    pytest.mark.spark,
+    pytest.mark.skipif(not spark_enabled, reason="spark tests disabled by default"),
+]
+
+try:
+    from pyspark import pandas as ps
+    from pyspark.sql import SparkSession
+except Exception:
+    pytest.skip("pyspark not available", allow_module_level=True)
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from spandas.enhanced.selection import iloc


### PR DESCRIPTION
## Summary
- slim core install to pandas/numpy/pyarrow/matplotlib
- gate pandas>=2 at import and make pyspark/dask optional extras
- mark spark/dask tests and run optional jobs in CI

## Testing
- `pytest -q`
- `pytest -q -m "dask"`
- `SPANDAS_ENABLE_SPARK_TESTS=1 pytest -q -m "spark"`


------
https://chatgpt.com/codex/tasks/task_e_689afb2d71608326a4c5d342082f2b94